### PR TITLE
[Loc] Find Fragments in Project Setup

### DIFF
--- a/nx/blocks/loc/setup/setup.css
+++ b/nx/blocks/loc/setup/setup.css
@@ -73,6 +73,72 @@ textarea {
   font-size: 14px;
 }
 
+/* Find Fragments */
+.fragments-modal {
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0 0 0 / 40%);
+}
+
+.fragments-modal h2 {
+  margin: 0;
+}
+
+.fragments-modal p {
+  margin-bottom: 5px;
+}
+
+.fragments-modal .content {
+  width: 65vw;
+  max-width: 800px;
+  background-color: #fefefe;
+  margin: 15% auto;
+  padding: 20px;
+  border: 1px solid #888;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+}
+
+.fragments-modal .found {
+  position: relative;
+  background-color: #f7f7f7;
+  border: 1px solid #ddd;
+  padding: 10px;
+  border-radius: 10px;
+  margin-bottom: 10px;
+}
+
+.fragments-modal .found .select-all {
+  position: absolute;
+  right: 9px;
+  cursor: pointer;
+}
+
+.fragments-modal .found .select-all::after {
+  content: '';
+  border: 1px solid #777;
+  border-right: 0;
+  border-bottom: 0;
+  border-radius: 2px;
+  width: 11px;
+  height: 11px;
+  display: inline-flex;
+  position: absolute;
+  top: 2px;
+  right: 7px;
+}
+
+.fragments-modal .found .fragment {
+  display: flex;
+  gap: 5px;
+}
+
 /* Lang Form */
 .lang-group {
   background: var(--s2-gray-75);

--- a/nx/styles/buttons.css
+++ b/nx/styles/buttons.css
@@ -1,11 +1,13 @@
 button,
-input[type="submit"] {
+input[type="submit"],
+input[type="button"] {
   background: none;
   font-family: var(--body-font-family);
   display: inline-block;
   font-style: normal;
   font-weight: 700;
   text-decoration: none;
+  cursor: pointer;
 }
 
 .action {
@@ -19,6 +21,7 @@ input[type="submit"] {
 
 .primary,
 .accent,
+.cancel,
 input[type="submit"].accent {
   padding: 5px 14px;
   line-height: 18px;
@@ -41,5 +44,20 @@ input[type="submit"].accent {
 input[type="submit"].accent:focus {
   background: #3b63fb;
   border: 2px solid #3b63fb;
+  outline-offset: 4px;
+}
+
+.cancel,
+input[type="button"].cancel {
+  background: #888;
+  border: 2px solid #888;
+  outline-color: #888;
+  color: #FFF;
+}
+
+.cancel:focus,
+input[type="button"].cancel:focus {
+  background: #666;
+  border: 2px solid #666;
   outline-offset: 4px;
 }

--- a/nx/utils/setup.js
+++ b/nx/utils/setup.js
@@ -1,0 +1,67 @@
+const DA_ORIGIN = 'https://admin.da.live';
+
+function getDaUrl(url) {
+  if (url.hostname === DA_ORIGIN) return url.href;
+  const [repo, org] = url.hostname.split('.')[0].split('--').slice(1).slice(-2);
+  return `${DA_ORIGIN}/source/${org}/${repo}${url.pathname}.html`;
+}
+
+async function parsePage(daUrl) {
+  const resp = await fetch(daUrl);
+  if (!resp.ok) return null;
+  const html = await resp.text();
+  const parser = new DOMParser();
+  const page = parser.parseFromString(html, 'text/html');
+  return page;
+}
+
+async function findPageFragments(url) {
+  const { origin } = new URL(url);
+  const daUrl = getDaUrl(url);
+  const html = await parsePage(daUrl);
+  if (!html) return [];
+  const pageLinks = html.querySelectorAll('a');
+  const pageFragments = [...pageLinks].reduce((fragments, link) => {
+    const dupe = fragments.some((ac) => ac.href === link.href);
+    if (dupe) return fragments;
+    const { pathname } = new URL(link.href);
+    if (pathname.includes('/fragments/')) {
+      fragments.push(new URL(`${origin}${link.pathname}`));
+    }
+    return fragments;
+  }, []);
+  return pageFragments;
+}
+
+async function findNestedFragments(url) {
+  const searched = [];
+  const fragments = await findPageFragments(url);
+  if (!fragments.length) return [];
+  while (fragments.length !== searched.length) {
+    const needsSearch = fragments.filter((fragment) => !searched.includes(fragment.pathname));
+    for (const search of needsSearch) {
+      const nestedFragments = await findPageFragments(search);
+      const notSearched = nestedFragments.filter((nested) => !searched.includes(nested.pathname));
+      if (notSearched?.length) fragments.push(...notSearched);
+      searched.push(search.pathname);
+    }
+  }
+  return fragments;
+}
+
+export async function findAllFragments(urls) {
+  const foundFragments = await urls.map((url) => findNestedFragments(url));
+  const pages = await Promise.all(foundFragments);
+  const allFragments = pages.reduce((fragments, page) => {
+    if (page.length > 0) {
+      page.forEach((pageFragment) => {
+        const dupe = fragments.some((fragment) => pageFragment.pathname === fragment.pathname);
+        if (!dupe) fragments.push(pageFragment);
+      });
+    }
+    return fragments;
+  }, []);
+  return allFragments;
+}
+
+export default { findAllFragments };


### PR DESCRIPTION
This PR introduces find fragments functionality within the loc setup process.
Includes:
- search all pages added to the urls textarea when the user clicks next
- parse and select all linked fragments that are nested within valid urls, levels deep
- UI dialog and checkbox selection area for selecting which fragment urls contained on pages should be added to new loc project config

Fix #<gh-issue-id> - _I do not currently have a ticket for this work_

Test URLs:
- Before: https://main--da-live--adobe.hlx.live/apps/loc
- After: https://find-fragments--da-live--sartxi.hlx.page/apps/loc
