### PR TITLE
Updating the pagination settings and making the project toggle less confusing

### DIFF
--- a/nx/blocks/loc/dashboard/dashboard.js
+++ b/nx/blocks/loc/dashboard/dashboard.js
@@ -28,7 +28,7 @@ class NxLocDashboard extends LitElement {
     this._projects = [];
     this._filteredProjects = [];
     this._currentPage = 1;
-    this._projectsPerPage = 5;
+    this._projectsPerPage = 50;
     this._loading = true;
   }
 

--- a/nx/blocks/loc/dashboard/filter-bar.js
+++ b/nx/blocks/loc/dashboard/filter-bar.js
@@ -157,7 +157,7 @@ class NxFilterBar extends LitElement {
           <label>
               <input type="checkbox" .checked=${!this.viewAllProjects} @change=${this.toggleViewAllProjects}/>
               <span class="slider"></span>
-              <span class="toggle-label">${this.viewAllProjects ? 'All Projects' : 'My Projects'}</span>
+              <span class="toggle-label">My Projects</span>
           </label>
         </div>
       </div>`;

--- a/nx/blocks/loc/dashboard/pagination.js
+++ b/nx/blocks/loc/dashboard/pagination.js
@@ -16,8 +16,6 @@ class NxPagination extends LitElement {
   constructor() {
     super();
     this.currentPage = 1;
-    this.totalItems = 0;
-    this.itemsPerPage = 10;
   }
 
   async connectedCallback() {


### PR DESCRIPTION
- Updating the pagination settings to display 50 projects per page. 
- Removed unnecessary initialization in constructor
- The toggle of `All Projects` vs `My Projects` will only show `My Projects`. Removed the label toggling.