### PR TITLE
GlaaS Target and Source preview

### DIFF
--- a/nx/blocks/loc/glaas/index.js
+++ b/nx/blocks/loc/glaas/index.js
@@ -1,5 +1,5 @@
 import {
-  checkSession, createTask, addAssets, updateStatus, getTask, downloadAsset,
+  checkSession, createTask, addAssets, updateStatus, getTask, downloadAsset, prepareTargetPreview,
 } from './api.js';
 import { getGlaasToken, connectToGlaas } from './auth.js';
 
@@ -66,7 +66,7 @@ async function createNewTask(service, task, setStatus) {
   setStatus(`Creating task ${task.name} using ${task.workflowName}.`);
 
   const { origin, clientid } = service;
-  const result = await createTask({ origin, clientid, token, task });
+  const result = await createTask({ origin, clientid, token, task, service });
   return { ...result, status: 'draft' };
 }
 
@@ -92,6 +92,7 @@ async function sendTask(service, suppliedTask, langs, urls, actions) {
     task.status = 'uploading';
     updateLangTask(task, langs);
     await addTaskAssets(service, langs, task, urls, actions);
+    await prepareTargetPreview(task, urls, service);
     updateLangTask(task, langs);
     await saveState();
   }

--- a/nx/blocks/loc/project/index.js
+++ b/nx/blocks/loc/project/index.js
@@ -37,6 +37,7 @@ export async function detectService(config, env = 'stage') {
       clientid: config[`translation.service.${env}.clientid`].value,
       actions: await import('../glaas/index.js'),
       dnt: await import('../glaas/dnt.js'),
+      preview: config[`translation.service.${env}.preview`].value,
     };
   }
   return {

--- a/nx/blocks/loc/project/new.js
+++ b/nx/blocks/loc/project/new.js
@@ -19,6 +19,7 @@ export default function normalizeUrls(urls, langs) {
     return {
       extPath: url.extPath,
       basePath,
+      originalHref: url.href,
     };
   });
 }


### PR DESCRIPTION
- Reading "preview" config to service to make the DALOC domain configurable in the .da config
- Adding call to DALOC to initialize a target-preview-only project so DALOC has all the metadata when the hook gets triggered
- Adding hook URL to metadata on GLaaS task-creation
- Fixing source preview URL

Fixes: #18
