### PR TITLE
add send html function to sdk

### DIFF
--- a/nx/utils/sdk.js
+++ b/nx/utils/sdk.js
@@ -6,6 +6,10 @@ function sendText(text) {
   port2.postMessage({ action: 'sendText', details: text });
 }
 
+function sendHTML(text) {
+  port2.postMessage({ action: 'sendHTML', details: text });
+}
+
 function setTitle(text) {
   port2.postMessage({ action: 'setTitle', details: text });
 }
@@ -29,6 +33,7 @@ const DA_SDK = (() => new Promise((resolve) => {
       const actions = {
         daFetch,
         sendText,
+        sendHTML,
         closeLibrary,
       };
 


### PR DESCRIPTION
Allow sending HTML from a guest plugin to the DA host.

Usecase: The commerce picker plugin needs to be able to insert blocks to the page.




https://github.com/user-attachments/assets/8275793a-608c-4226-9342-49702499e131

