### PR TITLE
use future location of boilerplate

### DIFF
--- a/nx/blocks/generator/create-site.js
+++ b/nx/blocks/generator/create-site.js
@@ -1,7 +1,7 @@
 import { crawl } from 'https://da.live/nx/public/utils/tree.js';
 import { loadIms } from '../../utils/ims.js';
 
-const { token } = await loadIms();
+const { accessToken: { token } } = await loadIms();
 
 const PLACEHOLDERS_DIR = 'TODO/da-sws/configs/';
 

--- a/nx/blocks/generator/generator.js
+++ b/nx/blocks/generator/generator.js
@@ -5,7 +5,7 @@ import { createSite } from './create-site.js';
 
 const style = await getStyle(import.meta.url);
 // const placeholders = [];
-const blueprints = [{ label: 'Blueprint', value: '/adobe-commerce/template' }];
+const blueprints = [{ label: 'Blueprint', value: '/adobe-commerce/commerce-boilerplate' }];
 
 // const onOpenPlaceholder = (item) => {
 //   const url = `https://da.live/sheet#${item.value}`;


### PR DESCRIPTION
Hit an issue with `/copy`. 
![image](https://github.com/user-attachments/assets/17f22955-190b-44ec-8a8a-8029878dff0f)

Seems like the ims token used in the req is not right? I thought da is open. Here's the permissions on the source org:

![image](https://github.com/user-attachments/assets/077e4f3e-e450-4c1b-8069-249928048525)

