### PR TITLE
add error handling to tree util

### DIFF
--- a/nx/public/utils/tree.js
+++ b/nx/public/utils/tree.js
@@ -83,7 +83,7 @@ export function crawl({ path, callback, concurrent, throttle = 100 }) {
   const folders = [path];
   const inProgress = [];
   const startTime = Date.now();
-  const queue = new Queue(callback, concurrent, (err, item) => errors.push({ item, err }));
+  const queue = new Queue(callback, concurrent, (item, err) => errors.push({ item, err }));
 
   const results = new Promise((resolve) => {
     const interval = setInterval(async () => {


### PR DESCRIPTION
This fixes 2 things:

* First, if a callback in tree throws an error, the queue never finishes, as `inProgress.pop()` never got executed
* Second, we now provide an array of all errors during callback execution to the caller

This *should* all be completely backwards-compatible, in order not to break any current users' code.

Test URLs:
- Before: https://main--nexter--da-sites.hlx.live/
- After: https://tree-error-handling--nexter--da-sites.hlx.live/
