### PR TITLE
use instance variable.

### DIFF
--- a/nx/blocks/loc/project/project.js
+++ b/nx/blocks/loc/project/project.js
@@ -47,7 +47,7 @@ class NxLocProject extends LitElement {
     this._langs = langs;
     this._urls = urls;
 
-    const needsSync = urls.some((url) => !url.extPath.startsWith(sourceLang.location));
+    const needsSync = urls.some((url) => !url.extPath.startsWith(this._sourceLang.location));
     const translateLangs = langs.filter((lang) => lang.action === 'translate');
     const rolloutLangs = langs.filter((lang) => lang.locales);
 


### PR DESCRIPTION
When trying to view a Translation Project (e.g. https://da.live/apps/loc#/{org}/{site}/.da/translation/projects/active/{id}), a JS error is thrown because the `sourceLang` variable is `undefined`. 

Changing this reference to `this._sourceLang` resolves the issue since a fallback value is already provided in that scenario a few lines above it `this._sourceLang = sourceLang || { location: '/' };`