### PR TITLE
DNT code blocks

### DIFF
--- a/nx/blocks/loc/dnt/dnt.js
+++ b/nx/blocks/loc/dnt/dnt.js
@@ -3,6 +3,8 @@ import decorateTable from './decorateTable.js';
 import parseQuery from './parseQuery.js';
 import { processAltText, resetAltText } from './processAltText.js';
 
+const DNT_ELEMENTS = ['code'];
+
 function removeDntAttributes(document) {
   const dntEls = document.querySelectorAll('[translate="no"]');
   dntEls.forEach((el) => { el.removeAttribute('translate'); });
@@ -94,6 +96,12 @@ const addDntInfoToHtml = (html, dntRules) => {
     findAndAddDntWrapper(document, dntContent);
   });
 
+  DNT_ELEMENTS.forEach((dntElement) => {
+    document.querySelectorAll(dntElement).forEach((el) => {
+      el.setAttribute('translate', 'no');
+    });
+  });
+
   processAltText(document, addDntWrapper);
   return document.documentElement.outerHTML;
 };
@@ -111,7 +119,6 @@ const extractPattern = (rule) => {
   return { condition, match };
 };
 
-// TODO memoize
 function parseConfig(config) {
   const docRules = config['custom-doc-rules']?.data || [];
   const contentRules = config['dnt-content-rules']?.data || [];

--- a/test/loc/dnt/dnt.test.js
+++ b/test/loc/dnt/dnt.test.js
@@ -114,6 +114,28 @@ describe('makeIconSpans', () => {
   });
 });
 
+describe('code blocks', () => {
+  it.only('adds dnt info to all html code blocks', async () => {
+    const html = `<html><head></head><body>
+      <main>
+        <div><code>console.log("Hello, world!");</code></div>
+        <div><code>const x = 1;</code></div>
+      </main>
+    </body></html>`;
+    const result = await addDnt(html, {});
+    console.log(result);
+    expect(result).to.equal(`<html><head></head><body>
+      <main>
+        <div><code translate="no">console.log("Hello, world!");</code></div>
+        <div><code translate="no">const x = 1;</code></div>
+      </main>
+    </body></html>`);
+
+    const removed = await removeDnt(result, 'adobecom', 'adobe');
+    expect(removed).to.equal(html);
+  });
+});
+
 describe('addDntInfoToHtml', () => {
   it('adds dnt info to html', async () => {
     const metadataTable = `<html><head></head><body>

--- a/test/loc/google/dnt.test.js
+++ b/test/loc/google/dnt.test.js
@@ -21,6 +21,30 @@ describe('Google DNT', () => {
     expect(htmlWithoutDnt).to.equal(expectedHtmlWithoutDnt);
   });
 
+  it('Converts code blocks to dnt', async () => {
+    const html = `<html><head></head><body>
+      <main>
+        <div><code>console.log("Hello, world!");</code></div>
+        <div><code>const x = 1;</code></div>
+      </main>
+    </body></html>`;
+    const result = await addDnt(html, {});
+    expect(result).to.equal(`<html><head></head><body>
+      <main>
+        <div><code data-inner-html="console.log(&quot;Hello, world!&quot;);"></code></div>
+        <div><code data-inner-html="const x = 1;"></code></div>
+      </main>
+    </body></html>`);
+
+    const removed = await removeDnt(result, 'adobecom', 'adobe');
+    // Google translate strips html and head tags
+    const removedHtml = `<body><main>
+        <div><code>console.log("Hello, world!");</code></div>
+        <div><code>const x = 1;</code></div>
+      </main></body>`;
+    expect(removed).to.equal(removedHtml);
+  });
+
   it('Converts json to dnt formatted html and back', async () => {
     const expectedHtmlWithDnt = await readFile({ path: './mocks/placeholders.html' });
     const json = await readFile({ path: './mocks/placeholders.json' });


### PR DESCRIPTION
Also preserves line breaks in code blocks that were being lost when sending to google translate previously.

Test URLs:
- Before: https://main--da-live--adobe.aem.live/apps/loc
- After: https://main--da-live--adobe.aem.live/apps/loc?nx=dnt-code
