### PR TITLE
Per lang cancel

### DIFF
--- a/nx/blocks/loc/views/rollout/index.js
+++ b/nx/blocks/loc/views/rollout/index.js
@@ -187,7 +187,7 @@ function getRolloutDetails(lang) {
 
 export function sortLangs(langs) {
   // Filter out any langs that do not have locales
-  const filtered = langs.filter((lang) => lang.locales.length);
+  const filtered = langs.filter((lang) => lang.locales.length && lang.translation?.status !== 'cancelled');
 
   return filtered.map((lang) => {
     const rollout = getRolloutDetails(lang);

--- a/nx/blocks/loc/views/steps/steps.js
+++ b/nx/blocks/loc/views/steps/steps.js
@@ -86,7 +86,7 @@ class NxLocSteps extends LitElement {
         translation: { saved: translationSaved = 0 } = {},
         copy: { saved: copySaved = 0 } = {},
       } = lang;
-      return action === 'rollout' || translationSaved + copySaved === this.urls.length;
+      return action === 'rollout' || translationSaved + copySaved === this.urls.length || lang.translation?.status === 'cancelled';
     });
   }
 

--- a/nx/blocks/loc/views/translate/translate.css
+++ b/nx/blocks/loc/views/translate/translate.css
@@ -23,6 +23,10 @@ p {
   .status-label {
     text-align: center;
   }
+
+  &.with-cancel {
+    grid-template-columns: 1fr 92px 92px 92px 92px 120px 68px;
+  }
 }
 
 ul {
@@ -46,6 +50,10 @@ ul {
       grid-template-columns: 1fr 92px 92px 92px 92px 120px;
       align-items: center;
       min-height: 20px;
+
+      &.with-cancel {
+        grid-template-columns: 1fr 92px 92px 92px 92px 120px 68px;
+      }
     }
 
     &::before,


### PR DESCRIPTION
- adding a button per language
- conditionally adding CSS for an additional column only if any language has a cancel button
- filtering out cancelled languages in the rollout view
- updating the check mark for translate step to count "cancelled" as completed lang
- updating GetStatusAll to account for differing status per language in the same task

