### PR TITLE
Wrap pictures+siblings in p tags during import

### DIFF
--- a/nx/utils/converters.js
+++ b/nx/utils/converters.js
@@ -57,18 +57,21 @@ function convertBlocks(editor) {
 
 function makePictures(dom) {
   const imgs = dom.querySelectorAll('img');
-  imgs.forEach((img) => {
-    const originalParent = img.parentElement;
-    const originalGrandparent = originalParent.parentElement;
+  imgs.forEach((originalImage) => {
+    const parent = originalImage.parentElement;
+    const grandParent = parent.parentElement;
 
     // Wrap the picture tags in a p tag if there are multiple children
     // Prevents https://github.com/adobe/helix-html2md/issues/747
-    if (originalParent.nodeName === 'DIV' && originalParent.childElementCount > 1) {
-      const paragraph = document.createElement('p');
-      paragraph.innerHTML = originalParent.innerHTML;
-      originalGrandparent.replaceChild(paragraph, originalParent);
+    let paragraph = originalImage.parentElement;
+    if (parent.nodeName === 'DIV' && parent.childElementCount > 1) {
+      const div = document.createElement('div');
+      paragraph = document.createElement('p');
+      paragraph.innerHTML = parent.innerHTML;
+      div.appendChild(paragraph);
+      grandParent.replaceChild(div, parent);
     }
-
+    const img = paragraph.querySelector('img') || originalImage;
     const clone = img.cloneNode(true);
     clone.setAttribute('loading', 'lazy');
     // MD can have hlx in the img src
@@ -100,12 +103,7 @@ function makePictures(dom) {
 
     // Determine what to replace
     const imgParent = img.parentElement;
-    const imgGrandparent = imgParent.parentElement;
-    if (imgParent.nodeName === 'P' && imgGrandparent?.childElementCount === 1) {
-      imgGrandparent.replaceChild(pic, imgParent);
-    } else {
-      imgParent.replaceChild(pic, img);
-    }
+    imgParent.replaceChild(pic, img);
   });
 }
 

--- a/nx/utils/converters.js
+++ b/nx/utils/converters.js
@@ -58,6 +58,17 @@ function convertBlocks(editor) {
 function makePictures(dom) {
   const imgs = dom.querySelectorAll('img');
   imgs.forEach((img) => {
+    const originalParent = img.parentElement;
+    const originalGrandparent = originalParent.parentElement;
+
+    // Wrap the picture tags in a p tag if there are multiple children
+    // Prevents https://github.com/adobe/helix-html2md/issues/747
+    if (originalParent.nodeName === 'DIV' && originalParent.childElementCount > 1) {
+      const paragraph = document.createElement('p');
+      paragraph.innerHTML = originalParent.innerHTML;
+      originalGrandparent.replaceChild(paragraph, originalParent);
+    }
+
     const clone = img.cloneNode(true);
     clone.setAttribute('loading', 'lazy');
     // MD can have hlx in the img src


### PR DESCRIPTION
Fixes #62 

### Description
Wrap the created pictures and siblings into a paragraph during import

Tested on/imported page:
https://main--da-bacom--adobecom.aem.live/no/solutions/content-supply-chain/creation-production/supercharge-teams
vs
https://main--bacom--adobecom.aem.live/no/solutions/content-supply-chain/creation-production/supercharge-teams


Test URLs:
- Before: https://main--nexter--da-sites.aem.live/
- After: https://wrap-pictures-in-p-tags--nexter--mokimo.aem.live/
Importer Test link: https://da.live/apps/import?nx=wrap-pictures-in-p-tags--nexter--mokimo

